### PR TITLE
make Ack suport longer argument list.

### DIFF
--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -13,7 +13,7 @@ if !exists("g:ackprg")
 	let g:ackprg="ack -H --nocolor --nogroup --column"
 endif
 
-function! s:Ack(cmd, args)
+function! s:Ack(cmd, args, ...)
     redraw
     echo "Searching ..."
 
@@ -21,7 +21,7 @@ function! s:Ack(cmd, args)
     if empty(a:args)
         let l:grepargs = expand("<cword>")
     else
-        let l:grepargs = a:args
+        let l:grepargs = a:args . join(a:000, ' ')
     end
 
     " Format, used to manage column jump


### PR DESCRIPTION
now:

:grep _word_ filename1.py filename2.py

or

:grep _word_ %

works well with quickfix window.
