### PR TITLE
g:ackdefaultdir option

### DIFF
--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -24,7 +24,7 @@ function! s:Ack(cmd, args)
         let l:grepargs = a:args
     end
 
-    if exists(g:ackdefaultdir)
+    if exists("g:ackdefaultdir")
       let l:grepargs = l:grepargs." ".g:ackdefaultdir
     end
 


### PR DESCRIPTION
I added this option because I don't like the idea of typing in the root of a project at every search. I find that Ack.vim is particularly useful when I can do project-searches. To be honest, I don't know if this is a good way of implementing it. It's working fine with me at the moment and I have done a pull-request just for sharing the idea. If you like it, I can do another commit with docs.

Thank you for the plugin!
