### PR TITLE
fix typo (when setting quickfix mappings)

### DIFF
--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -12,7 +12,7 @@ if !exists("g:ackprg")
 endif
 
 if !exists("g:ack_apply_qmappings")
-  let g:ack_apply_mappings = !exists("g:ack_qhandler")
+  let g:ack_apply_qmappings = !exists("g:ack_qhandler")
 endif
 
 if !exists("g:ack_apply_lmappings")


### PR DESCRIPTION
Fix the following error when using :Ack instead of :LAck

```
Error detected while processing function <SNR>19_Ack:
line   35:
E121: Undefined variable: g:ack_apply_qmappings
E15: Invalid expression: g:ack_apply_qmappings
line   38:
E121: Undefined variable: l:apply_mappings
E15: Invalid expression: l:apply_mappings
```
