### PR TITLE
Add optional (fallback) grepformat to g:ackformat

### DIFF
--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -42,7 +42,7 @@ function! s:Ack(cmd, args)
   if a:cmd =~# '-g$'
     let g:ackformat="%f"
   else
-    let g:ackformat="%f:%l:%c:%m"
+    let g:ackformat="%f:%l:%c:%m,%f:%l:%m"
   end
 
   let grepprg_bak=&grepprg


### PR DESCRIPTION
`grepformat` can hold multiple values separated by commas. When parsing results Vim tries to match lines against each of formats specified.

I added additional format `%f:%l:%m` that doesn't include column. This allows using `git-grep` (that don't have an option to output column number) with this plugin just by setting `g:ackprg` like this:

```
let g:ackprg = 'git grep -H --line-number --no-color'
```
