### PR TITLE
Add the possibility to automatically close the quick window

### DIFF
--- a/doc/ack.txt
+++ b/doc/ack.txt
@@ -45,7 +45,7 @@ shows the results in a split window.
 
 :AckHelp[!] [options] {pattern}                                      *:AckHelp*
 
-    Search vim documentation files for the {pattern}.  Behaves just like the 
+    Search vim documentation files for the {pattern}.  Behaves just like the
     |:Ack| command, but searches only vim documentation .txt files
 
 :LAckHelp [options] {pattern}                                        *:LAckHelp*
@@ -82,3 +82,18 @@ v                   open in vertical split.
 gv                  open in vertical split silently.
 
 q                   close the quickfix window.
+
+==============================================================================
+CONFIGURATION                                              *ack-configuration*
+
+                                                             *g:ack_autoclose*
+g:ack_autoclose
+Default: 0
+
+Use this option to specify whether to close the quickfix window after using
+any of the shortcuts.
+
+Example:
+>
+        let g:ack_autoclose = 1
+<

--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -67,15 +67,28 @@ function! s:Ack(cmd, args)
   endif
 
   if l:apply_mappings
-    exec "nnoremap <silent> <buffer> q :ccl<CR>"
-    exec "nnoremap <silent> <buffer> t <C-W><CR><C-W>T"
-    exec "nnoremap <silent> <buffer> T <C-W><CR><C-W>TgT<C-W><C-W>"
-    exec "nnoremap <silent> <buffer> o <CR>"
-    exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
-    exec "nnoremap <silent> <buffer> h <C-W><CR><C-W>K"
-    exec "nnoremap <silent> <buffer> H <C-W><CR><C-W>K<C-W>b"
-    exec "nnoremap <silent> <buffer> v <C-W><CR><C-W>H<C-W>b<C-W>J<C-W>t"
-    exec "nnoremap <silent> <buffer> gv <C-W><CR><C-W>H<C-W>b<C-W>J"
+    if !exists("g:ack_autoclose") || !g:ack_autoclose
+      exec "nnoremap <silent> <buffer> q :ccl<CR>"
+      exec "nnoremap <silent> <buffer> t <C-W><CR><C-W>T"
+      exec "nnoremap <silent> <buffer> T <C-W><CR><C-W>TgT<C-W><C-W>"
+      exec "nnoremap <silent> <buffer> o <CR>"
+      exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
+      exec "nnoremap <silent> <buffer> h <C-W><CR><C-W>K"
+      exec "nnoremap <silent> <buffer> H <C-W><CR><C-W>K<C-W>b"
+      exec "nnoremap <silent> <buffer> v <C-W><CR><C-W>H<C-W>b<C-W>J<C-W>t"
+      exec "nnoremap <silent> <buffer> gv <C-W><CR><C-W>H<C-W>b<C-W>J"
+    else
+      exec "nnoremap <silent> <buffer> q :ccl<CR>"
+      exec "nnoremap <silent> <buffer> t <C-W><CR><C-W>T:ccl<CR>"
+      exec "nnoremap <silent> <buffer> T <C-W><CR><C-W>TgT<C-W><C-W>:ccl<CR>"
+      exec "nnoremap <silent> <buffer> o <CR>:ccl<CR>"
+      exec "nnoremap <silent> <buffer> <CR> <CR>:ccl<CR>"
+      exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>:ccl<CR>"
+      exec "nnoremap <silent> <buffer> h <C-W><CR><C-W>K:ccl<CR>"
+      exec "nnoremap <silent> <buffer> H <C-W><CR><C-W>K<C-W>b:ccl<CR>"
+      exec "nnoremap <silent> <buffer> v <C-W><CR><C-W>H<C-W>b<C-W>J<C-W>t:ccl<CR>"
+      exec "nnoremap <silent> <buffer> gv <C-W><CR><C-W>H<C-W>b<C-W>J:ccl<CR>"
+    endif
   endif
 
   " If highlighting is on, highlight the search keyword.


### PR DESCRIPTION
A one can now automatically close the quickfix window after opening a file using the `g:ack_autoclose` global variable.

The default behavior remains unchanged.

Cf. issue https://github.com/mileszs/ack.vim/issues/85
