### PR TITLE
if ack is not installed finish script

### DIFF
--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -10,6 +10,9 @@
 " Location of the ack utility
 if !exists("g:ackprg")
   let s:ackcommand = executable('ack-grep') ? 'ack-grep' : 'ack'
+  if !executable(s:ackcommand)
+    finish
+  endif
   let g:ackprg = s:ackcommand." -H --nocolor --nogroup --column"
 endif
 


### PR DESCRIPTION
if the ack program is not installed, finish the script of plugin,

if ack is not installed, why use the plugin ? 

I use ack.vim as a submodule of a git repo with dotfiles and vim configurations files, and when I use the configurations files in windows (with cygwin), I don't have installed ack program.
