### PR TITLE
Fix for ack command not installed.

### DIFF
--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -13,8 +13,6 @@ if !exists("g:ackprg")
   let g:ackprg = s:ackcommand." -H --nocolor --nogroup --column"
 endif
 
-let s:ackprg_version = eval(matchstr(system(g:ackprg . " --version"),  '[0-9.]\+'))
-
 if !exists("g:ack_apply_qmappings")
   let g:ack_apply_qmappings = !exists("g:ack_qhandler")
 endif
@@ -45,6 +43,10 @@ function! s:Ack(cmd, args)
   else
     let l:grepargs = a:args . join(a:000, ' ')
   end
+
+  if !exists("s:ackprg_version")
+    let s:ackprg_version = eval(matchstr(system(g:ackprg . " --version"),  '[0-9.]\+'))
+  endif
 
   " Format, used to manage column jump
   if a:cmd =~# '-g$'


### PR DESCRIPTION
Raised error on ack not installed server environment:

```
Error detected while processing /home/yudoufu/dotfiles/.vim/bundle/ack.vim/plugin/ack.vim:
line   16:
E15: Invalid expression: 
```

so, I fixed `s:ackprg_version` execution place. 
