### PR TITLE
fix hightlighting issue when working with ack options

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -111,7 +111,19 @@ function! s:highlight(args)
     return
   endif
 
-  let @/ = matchstr(a:args, "\\v\\w+\>|['\"]\\zs[^\"]+\\ze['\"]")
+  let input=a:args
+  let only_match=""
+
+  while ( 1 )
+    let only_match = substitute( input, '\v^\s*--?\w+\s*', '', '' )
+    if ( only_match != input )
+      let input = only_match
+    else
+      break
+    endif
+  endwhile
+
+  let @/ = matchstr(only_match, "\\v\\w+\>|['\"]\\zs[^\"]+\\ze['\"]")
   call feedkeys(":let &l:hlsearch=1 \| echo \<CR>", "n")
 endfunction
 


### PR DESCRIPTION
I came across this bug today: set g:ackhighlight = 1 and do
 :Ack -i something

This will result in every "w" being highlighted in your current window
and in the quick fix list. I "fixed" this by trying to strip out any
options before the actual search string.

The code is a bad hack and if you happen to also specifiy directories
for ack to search in, they will still be highlighted. But the code kind
of works and I didn't want to simply open an issue.
