### PR TITLE
finally fix highlighting with and without any Ack options

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -111,7 +111,7 @@ function! s:highlight(args)
     return
   endif
 
-  let @/ = matchstr(a:args, "\\v\\w+\>|['\"]\\zs[^\"]+\\ze['\"]")
+  let @/ = matchstr(a:args, "\\v\\zs[^- ]\\w+\>|['\"]\\zs[^\"]+\\ze['\"]")
   call feedkeys(":let &l:hlsearch=1 \| echo \<CR>", "n")
 endfunction
 


### PR DESCRIPTION
This is the [fix](https://github.com/mileszs/ack.vim/pull/131#issuecomment-44779687) I was talking about.
