### PR TITLE
Fix readme dl link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ rather than installing by drag and drop all required files into your `.vim` fold
 
 Just
 [download](https://github.com/mileszs/ack.vim/archive/master.zip) the
-plugin and put it in your `~/.vim/`(or `%PROGRAMFILES%/Vim/vimfiles` on windows)
+plugin and extract it in `~/.vim/`(or `%PROGRAMFILES%/Vim/vimfiles` on windows)
 
 #### Vundle
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ rather than installing by drag and drop all required files into your `.vim` fold
 #### Manual (not recommended)
 
 Just
-[download](https://github.com/mileszs/ack.vim/archive/kb-improve-readme.zip) the
+[download](https://github.com/mileszs/ack.vim/archive/master.zip) the
 plugin and put it in your `~/.vim/`(or `%PROGRAMFILES%/Vim/vimfiles` on windows)
 
 #### Vundle


### PR DESCRIPTION
* Change link from https://github.com/mileszs/ack.vim/archive/kb-improve-readme.zip to https://github.com/mileszs/ack.vim/archive/master.zip
* Change wording in README with clearer manual install instructions

Fixes issue #148.