### PR TITLE
Use qhandler with Dispatch, not plain copen

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -53,7 +53,7 @@ function! ack#Ack(cmd, args)
   if !g:ack_use_dispatch
     call ack#show_results()
   else
-    copen
+    execute s:handler
   endif
   call <SID>apply_maps()
   call <SID>highlight(l:grepargs)

--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -22,7 +22,13 @@ if !exists("g:ack_apply_lmappings")
   let g:ack_apply_lmappings = !exists("g:ack_lhandler")
 endif
 
-if !exists("g:ack_use_dispatch")
+if exists("g:ack_use_dispatch")
+  if g:ack_use_dispatch && !exists(":Dispatch")
+    let msg = "Ack: Dispatch not loaded! Falling back to g:ack_use_dispatch = 0."
+    echohl WarningMsg | echom msg | echohl None
+    let g:ack_use_dispatch = 0
+  endif
+else
   let g:ack_use_dispatch = 0
 end
 


### PR DESCRIPTION
Otherwise e.g. when you have vertical splits open, the quickfix list will not span the full bottom of the Vim window like standard ack.vim behavior.