### PR TITLE
Search by a visual mode selection

### DIFF
--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -63,16 +63,16 @@ if !exists("g:ack_autofold_results")
   let g:ack_autofold_results = 0
 endif
 
-command! -bang -nargs=* -complete=file Ack           call ack#Ack('grep<bang>', <q-args>)
-command! -bang -nargs=* -complete=file AckAdd        call ack#Ack('grepadd<bang>', <q-args>)
-command! -bang -nargs=* -complete=file AckFromSearch call ack#AckFromSearch('grep<bang>', <q-args>)
-command! -bang -nargs=* -complete=file LAck          call ack#Ack('lgrep<bang>', <q-args>)
-command! -bang -nargs=* -complete=file LAckAdd       call ack#Ack('lgrepadd<bang>', <q-args>)
-command! -bang -nargs=* -complete=file AckFile       call ack#Ack('grep<bang> -g', <q-args>)
-command! -bang -nargs=* -complete=help AckHelp       call ack#AckHelp('grep<bang>', <q-args>)
-command! -bang -nargs=* -complete=help LAckHelp      call ack#AckHelp('lgrep<bang>', <q-args>)
-command! -bang -nargs=*                AckWindow     call ack#AckWindow('grep<bang>', <q-args>)
-command! -bang -nargs=*                LAckWindow    call ack#AckWindow('lgrep<bang>', <q-args>)
+command! -bang -nargs=* -range=0 -complete=file Ack           call ack#Ack('grep<bang>', <q-args>, '', <count>)
+command! -bang -nargs=* -range=0 -complete=file AckAdd        call ack#Ack('grepadd<bang>', <q-args>, '', <count>)
+command! -bang -nargs=* -range=0                AckWindow     call ack#AckWindow('grep<bang>', <q-args>, <count>)
+command! -bang -nargs=* -range=0 -complete=file LAck          call ack#Ack('lgrep<bang>', <q-args>, '', <count>)
+command! -bang -nargs=* -range=0 -complete=file LAckAdd       call ack#Ack('lgrepadd<bang>', <q-args>, '', <count>)
+command! -bang -nargs=* -range=0                LAckWindow    call ack#AckWindow('lgrep<bang>', <q-args>, <count>)
+command! -bang -nargs=* -range=0 -complete=help AckHelp       call ack#AckHelp('grep<bang>', <q-args>, <count>)
+command! -bang -nargs=* -range=0 -complete=help LAckHelp      call ack#AckHelp('lgrep<bang>', <q-args>, <count>)
+command! -bang -nargs=* -range=0 -complete=file AckFile       call ack#Ack('grep<bang> -g', <q-args>, '', <count>)
+command! -bang -nargs=*          -complete=file AckFromSearch call ack#AckFromSearch('grep<bang>', <q-args>)
 
 let g:loaded_ack = 1
 


### PR DESCRIPTION
This pull request enables the `:Ack` family of commands to work on visual selections. If the user marks an area of text and types `:Ack`, the contents of the visual selection will be used as a search term. The other two cases, an `:Ack` that uses the word under the cursor, and `:Ack <term>` which uses the given argument as a query, still work.

The text is given as-is, which means if there are special characters in there, the results might be unexpected (say, marking `char* variable` would consider the `*` a special character). Still, this has often been a useful shortcut for me, even if it does break down for more complicated expressions (sometimes, just one `<cword>` is not enough).

Note that this also fixes an issue I've (just) noticed with `:AckWindow` and, I thnk, `:AckHelp` -- if you use them without arguments, taking the word under the cursor, they don't work. That's because the helper functions concatenate the empty argument list with a list of files, so `a:args` is no longer empty and the code doesn't take the word under the cursor into account. If this PR is not accepted, I can make a separate pull request with just this fix. Incidentally, the reason I can't test `:AckHelp` properly is that I seem to have so many plugins that the combined resulting command-line is too long to process correctly :). But I can't think of a good fix to that.

I'd like to add a note to the documentation about the visual mode search, but I'm not sure where to do it. I think the documentation doesn't mention the "word under the cursor" functionality, so maybe we should add that somewhere as well?

I also have two additional features I'd like to propose, but it'll take me some time to prepare pull requests.
