### PR TITLE
Add missing q quickfix shortcut to quick help

### DIFF
--- a/doc/ack_quick_help.txt
+++ b/doc/ack_quick_help.txt
@@ -1,14 +1,15 @@
 ====  ack.vim quick help ===============
 
-  *?:*  Show/quit this help
-  *t:*  Open in a new tab
-  *T:*  Open in a new tab silently
-  *o:*  Open
-  *O:*  Open and close result window
- *go:*  Preview
-  *h:*  Horizontal open
-  *H:*  Horizontal open silently
-  *v:*  Vertical open
- *gv:*  Vertical open silently
+  *?:*  a quick summary of these keys, repeat to close
+  *o:*  to open (same as Enter)
+  *O:*  to open and close the quickfix window
+ *go:*  to preview file, open but maintain focus on ack.vim results
+  *t:*  to open in new tab
+  *T:*  to open in new tab without moving to it
+  *h:*  to open in horizontal split
+  *H:*  to open in horizontal split, keeping focus on the results
+  *v:*  to open in vertical split
+ *gv:*  to open in vertical split, keeping focus on the results
+  *q:*  to close the quickfix window
 
 ========================================


### PR DESCRIPTION
The q shortcut is in the README.md but missing from the actual help doc. This commit adds it.