### PR TITLE
Add option to disable blank searches

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -26,6 +26,14 @@ function! ack#Ack(cmd, args) "{{{
     let l:grepformat = '%f'
   endif
 
+  " Check user policy for blank searches
+  if empty(a:args)
+    if !g:ack_use_cword_for_empty_search
+      echo "No regular expression found."
+      return
+    endif
+  endif
+
   " If no pattern is provided, search for the word under the cursor
   let l:grepargs = empty(a:args) ? expand("<cword>") : a:args . join(a:000, ' ')
 

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -37,6 +37,12 @@ function! ack#Ack(cmd, args) "{{{
   " If no pattern is provided, search for the word under the cursor
   let l:grepargs = empty(a:args) ? expand("<cword>") : a:args . join(a:000, ' ')
 
+  "Bypass search if cursor is on blank string
+  if l:grepargs == ""
+    echo "No regular expression found."
+    return
+  endif
+
   " NOTE: we escape special chars, but not everything using shellescape to
   "       allow for passing arguments etc
   let l:escaped_args = escape(l:grepargs, '|#%')

--- a/doc/ack.txt
+++ b/doc/ack.txt
@@ -230,6 +230,22 @@ Example:
         let g:ack_use_dispatch = 1
 <
 
+                                             *g:ack_use_cword_for_empty_search*
+
+g:ack_use_cword_for_empty_search
+Default: 1
+
+Use this option to enable blank searches to run against the word under the
+cursor. When this option is not set, blank searches will only output an error
+message.
+
+
+Example:
+>
+        let g:ack_use_cword_for_empty_search = 0
+<
+
+
 ==============================================================================
 MAPPINGS                                                        *ack-mappings*
 

--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -63,6 +63,10 @@ if !exists("g:ack_autofold_results")
   let g:ack_autofold_results = 0
 endif
 
+if !exists("g:ack_use_cword_for_empty_search")
+  let g:ack_use_cword_for_empty_search = 1
+endif
+
 command! -bang -nargs=* -complete=file Ack           call ack#Ack('grep<bang>', <q-args>)
 command! -bang -nargs=* -complete=file AckAdd        call ack#Ack('grepadd<bang>', <q-args>)
 command! -bang -nargs=* -complete=file AckFromSearch call ack#AckFromSearch('grep<bang>', <q-args>)


### PR DESCRIPTION
This pull request adds an option to disable blank searches. Current behaviour runs blank search against the word under the cursor. Setting the 'g:ack_no_blank_search' changes this behaviour to echo an error message and return.

It also bypasses search through the ack package if the cursor is under empty string