### PR TITLE
Look for `ack-grep` before `ack`

### DIFF
--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -8,10 +8,10 @@ endif
 
 " Location of the ack utility
 if !exists("g:ackprg")
-  if executable('ack')
-    let g:ackprg = "ack"
-  elseif executable('ack-grep')
+  if executable('ack-grep')
     let g:ackprg = "ack-grep"
+  elseif executable('ack')
+    let g:ackprg = "ack"
   else
     finish
   endif


### PR DESCRIPTION
On Ubuntu and Debain systems there are both the `ack` and `ack-grep`
packages. The problem is if a user has both installed we use the
incorrect `ack` package.

These changes will look for and use the `ack-grep` package before
`ack` incase a user has them both installed.