### PR TITLE
Fix `:AckWindow` for word-under-cursor searches

### DIFF
--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -67,12 +67,12 @@ if !exists("g:ack_use_cword_for_empty_search")
   let g:ack_use_cword_for_empty_search = 1
 endif
 
-command! -bang -nargs=* -complete=file Ack           call ack#Ack('grep<bang>', <q-args>)
-command! -bang -nargs=* -complete=file AckAdd        call ack#Ack('grepadd<bang>', <q-args>)
+command! -bang -nargs=* -complete=file Ack           call ack#Ack('grep<bang>', <q-args>, [])
+command! -bang -nargs=* -complete=file AckAdd        call ack#Ack('grepadd<bang>', <q-args>, [])
 command! -bang -nargs=* -complete=file AckFromSearch call ack#AckFromSearch('grep<bang>', <q-args>)
-command! -bang -nargs=* -complete=file LAck          call ack#Ack('lgrep<bang>', <q-args>)
-command! -bang -nargs=* -complete=file LAckAdd       call ack#Ack('lgrepadd<bang>', <q-args>)
-command! -bang -nargs=* -complete=file AckFile       call ack#Ack('grep<bang> -g', <q-args>)
+command! -bang -nargs=* -complete=file LAck          call ack#Ack('lgrep<bang>', <q-args>, [])
+command! -bang -nargs=* -complete=file LAckAdd       call ack#Ack('lgrepadd<bang>', <q-args>, [])
+command! -bang -nargs=* -complete=file AckFile       call ack#Ack('grep<bang> -g', <q-args>, [])
 command! -bang -nargs=* -complete=help AckHelp       call ack#AckHelp('grep<bang>', <q-args>)
 command! -bang -nargs=* -complete=help LAckHelp      call ack#AckHelp('lgrep<bang>', <q-args>)
 command! -bang -nargs=*                AckWindow     call ack#AckWindow('grep<bang>', <q-args>)


### PR DESCRIPTION
As discussed in https://github.com/mileszs/ack.vim/pull/171, this PR only fixes a bug with `:AckWindow` and `:AckHelp`.

Basically, if an argument was not given, the command doesn't take the word under the cursor, since the locations that are given to the `ack#Ack()` function work as an "args" argument. Separating "args" and "locations" fixes the issue.

Since locations are only used internally (if a user enters locations, they'll just be stuck in the catch-all `args` argument), it makes more sense for them to be a list. 

<hr>

A different way of handling this would be to provide a dict with "options" or something, ruby-style. That way, any additional params that need to be communicated between functions privately would not need to change the signature.

Or, argument handling could somehow be extracted to a separate function, so every one of `ack#AckWindow`, `ack#Ack` and so on invokes it first, something like:

``` vim
let [args, other_stuff] = s:ParseArgs(a:args, a:count, a:etc_etc)
if args == ''
  return
endif
```

Or something. There would still be some extra work, since `ack#AckWindow` calls `ack#Ack`, so both would have to do argument parsing, so I don't know if it's a good approach.

<hr>

Anyway, I'd rather just go for this solution, since I think it's simple enough and doesn't seem to have a lot of drawbacks. But let me know what you think.