### PR TITLE
Fix :AckHelp command bug with missing *.txt files

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -136,7 +136,7 @@ endfunction "}}}
 function! s:GetDocLocations() "{{{
   let dp = []
   for p in split(&rtp, ',')
-    let p = p . '/doc/'
+    let p = fnamemodify(p . '/doc/', ':~:.')
     if isdirectory(p)
       call extend(dp, glob(p . '*.txt', 0, 1))
     endif

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -134,15 +134,15 @@ function! s:ApplyMappings() "{{{
 endfunction "}}}
 
 function! s:GetDocLocations() "{{{
-  let dp = ''
+  let dp = []
   for p in split(&rtp, ',')
     let p = p . '/doc/'
     if isdirectory(p)
-      let dp = p . '*.txt ' . dp
+      call extend(dp, glob(p . '*.txt', 0, 1))
     endif
   endfor
 
-  return dp
+  return join(dp, ' ')
 endfunction "}}}
 
 function! s:Highlight(args) "{{{


### PR DESCRIPTION
If there are no *.txt files in one of the doc directories, the ack command errors out. Globbing for those files while generating the file list fixes the issue.

I've also added an extra improvement that I can remove if you'd prefer. The `fnamemodify` call shortens the file path as much as possible, so, if I'm running `:AckHelp` from within `/home/andrew/.vim`, instead of getting paths like `/home/andrew/.vim/bundle/ack/...`, I just get `bundle/ack/...`. This seems to make a difference to my quickfix window, at least.