### PR TITLE
Open qf or loc only when results found fixes (#225)

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -100,13 +100,10 @@ function! ack#ShowResults() "{{{
   " list window early and wait for it to populate :-/
   if g:ack_use_dispatch || s:HasResults()
     execute l:handler
+    call s:ApplyMappings()
+    redraw!
   else
     echo "No results found."
-  endif
-  call s:ApplyMappings()
-  " Redraw not needed when quickfix or locationlist were not opened.
-  if g:ack_use_dispatch || s:HasResults()
-    redraw!
   endif
 endfunction "}}}
 

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -96,7 +96,13 @@ endfunction "}}}
 
 function! ack#ShowResults() "{{{
   let l:handler = s:UsingLocList() ? g:ack_lhandler : g:ack_qhandler
-  execute l:handler
+  " Dispatch has no callback mechanism currently, we just have to display the
+  " list window early and wait for it to populate :-/
+  if g:ack_use_dispatch || s:HasResults()
+    execute l:handler
+  else
+    echo "No results found."
+  endif
   call s:ApplyMappings()
   redraw!
 endfunction "}}}
@@ -104,6 +110,11 @@ endfunction "}}}
 "-----------------------------------------------------------------------------
 " Private API
 "-----------------------------------------------------------------------------
+
+function! s:HasResults() "{{{
+  let l:win_filtered_results = s:UsingLocList() ? len(filter(getloclist(0), 'v:val.valid')) : len(filter(getqflist(), 'v:val.valid'))
+  return l:win_filtered_results
+endfunction "}}}
 
 function! s:ApplyMappings() "{{{
   if !s:UsingListMappings() || &filetype != 'qf'

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -104,7 +104,10 @@ function! ack#ShowResults() "{{{
     echo "No results found."
   endif
   call s:ApplyMappings()
-  redraw!
+  " Redraw not needed when quickfix or locationlist were not opened.
+  if g:ack_use_dispatch || s:HasResults()
+    redraw!
+  endif
 endfunction "}}}
 
 "-----------------------------------------------------------------------------

--- a/doc/ack.txt
+++ b/doc/ack.txt
@@ -71,6 +71,9 @@ Files containing the search term will be listed in the split window, along
 with the line number of the occurrence, once for each occurrence.  <Enter> on
 a line in this window will open the file, and place the cursor on the matching
 line.
+When no results are found, the location list or quick fix window won't be
+displayed. Instead message "No results found." will be printed. Note, this doesn't
+apply when using Dispatch.
 
 Note that if you are using Dispatch.vim with |g:ack_use_dispatch|, location
 lists are not supported, because Dispatch does not support them at this time.


### PR DESCRIPTION
Ack opens quickfix also when no results found #225.
When not used with Dispatch, we check if location list or quick fix list were populated with valid results before opening them.