### PR TITLE
escape special chars in `<cword>` when run `:Ack<CR>`

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -39,7 +39,13 @@ function! ack#Ack(cmd, args) "{{{
   endif
 
   " If no pattern is provided, search for the word under the cursor
-  let l:grepargs = empty(a:args) ? expand("<cword>") : a:args . join(a:000, ' ')
+  if empty(a:args)
+    let l:grepargs = expand("<cword>")
+    " escape special chars in <cword>
+    let l:grepargs = escape(l:grepargs, '$')
+  else
+    let l:grepargs = a:args . join(a:000, ' ')
+  endif
 
   "Bypass search if cursor is on blank string
   if l:grepargs == ""

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -42,7 +42,8 @@ function! ack#Ack(cmd, args) "{{{
   if empty(a:args)
     let l:grepargs = expand("<cword>")
     " escape special chars in <cword> and wrap in '
-    let l:grepargs = "'" . escape(l:grepargs, '$') . "'"
+    " use " instead of ', for 'xxx' will cause no effect on windows
+    let l:grepargs = '"' . escape(l:grepargs, '$') . '"'
   else
     let l:grepargs = a:args . join(a:000, ' ')
   endif

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -41,8 +41,8 @@ function! ack#Ack(cmd, args) "{{{
   " If no pattern is provided, search for the word under the cursor
   if empty(a:args)
     let l:grepargs = expand("<cword>")
-    " escape special chars in <cword>
-    let l:grepargs = escape(l:grepargs, '$')
+    " escape special chars in <cword> and wrap in '
+    let l:grepargs = "'" . escape(l:grepargs, '$') . "'"
   else
     let l:grepargs = a:args . join(a:000, ' ')
   endif


### PR DESCRIPTION
In javascript / php,  `$` is valid in  a variable.

```javascript
function $sayHello () {}
```
If we run `:Ack<CR>` when cursor is under `$sayHello`, nothing will be found.

So try to escape `$` and wrap `<cword>` in `'` .