### PR TITLE
Async support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Present maintainer, yours truly, [kind of wishes they never forked][sadface],
 contributes to both, and wouldn't mind seeing them merged again. ag.vim got a
 nice code clean-up (which ack.vim is now hopefully getting), and ack.vim picked
 up a few features that haven't made their way to ag.vim, like `:AckWindow`,
-optional background search execution with [vim-dispatch], and auto-previewing.
+optional background search execution with [vim-dispatch] or [async.vim], and
+auto-previewing.
 
 #### I don't want to jump to the first result automatically. ####
 
@@ -156,4 +157,5 @@ And of course, where would we be without [ack]. And, you know, Vim.
 [ack]: http://beyondgrep.com/
 
 [vim-dispatch]: https://github.com/tpope/vim-dispatch
+[async.vim]: https://github.com/prabirshrestha/async.vim
 [releases]: https://github.com/mileszs/ack.vim/releases

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -253,20 +253,11 @@ function! s:SearchWithAsync(grepprg, grepargs, grepformat, success_cb) "{{{
       let &l:errorformat = self.ctx.grepformat
       let entries = filter(self.ctx.data, 'len(v:val)')
 
+      let mode = s:UsingExistingQFLocList() ? 'a' : 'r'
       if s:UsingLocList()
-          if s:UsingExistingQFLocList()
-              laddexpr entries
-          else
-              lgetexpr entries
-          endif
-          call setloclist(0, [], 'a', { 'title': self.ctx.title })
+          call setloclist(0, entries, mode, { 'title': self.ctx.title })
       else
-          if s:UsingExistingQFLocList()
-            caddexpr entries
-          else
-            cgetexpr entries
-          endif
-          call setqflist([], 'a', { 'title': self.ctx.title })
+          call setqflist(entries, mode, { 'title': self.ctx.title })
       endif
     finally
       let &l:errorformat = errorformat_bak

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -253,11 +253,20 @@ function! s:SearchWithAsync(grepprg, grepargs, grepformat, success_cb) "{{{
       let &l:errorformat = self.ctx.grepformat
       let entries = filter(self.ctx.data, 'len(v:val)')
 
-      let mode = s:UsingExistingQFLocList() ? 'a' : 'r'
       if s:UsingLocList()
-          call setloclist(0, entries, mode, { 'title': self.ctx.title })
+          if s:UsingExistingQFLocList()
+              laddexpr entries
+          else
+              lgetexpr entries
+          endif
+          call setloclist(0, [], 'a', { 'title': self.ctx.title })
       else
-          call setqflist(entries, mode, { 'title': self.ctx.title })
+          if s:UsingExistingQFLocList()
+            caddexpr entries
+          else
+            cgetexpr entries
+          endif
+          call setqflist([], 'a', { 'title': self.ctx.title })
       endif
     finally
       let &l:errorformat = errorformat_bak

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -247,10 +247,14 @@ function! s:SearchWithAsync(grepprg, grepargs, grepformat, success_cb) "{{{
   endfunction "}}}
 
   function! ctx.complete(job_id, data, event_type) " {{{
-    let l:errorformat_bak = &l:errorformat
+    " Later on we are using {c,l}addexpr and {c,l}getexpr to populate
+    " the quickfix/location-list, and these use the global errorformat so
+    " that's what needs to be temporarily changed.
+    " https://github.com/vim/vim/issues/569
+    let l:errorformat_bak = &errorformat
 
     try
-      let &l:errorformat = self.ctx.grepformat
+      let &errorformat = self.ctx.grepformat
       let entries = filter(self.ctx.data, 'len(v:val)')
 
       if s:UsingLocList()
@@ -269,7 +273,7 @@ function! s:SearchWithAsync(grepprg, grepargs, grepformat, success_cb) "{{{
           call setqflist([], 'a', { 'title': self.ctx.title })
       endif
     finally
-      let &l:errorformat = errorformat_bak
+      let &errorformat = errorformat_bak
     endtry
     call self.ctx.success_cb()
   endfunction "}}}

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -164,7 +164,7 @@ endfunction "}}}
 function! s:Init(cmd) "{{{
   let s:searching_filepaths       = (a:cmd =~# '-g$') ? 1 : 0
   let s:using_loclist             = (a:cmd =~# '^l') ? 1 : 0
-  let s:using_existing_qfloc_list = (a:cmd =~# '^l?grepadd') ? 1 : 0
+  let s:using_existing_qfloc_list = (a:cmd =~# '^l\?grepadd') ? 1 : 0
 
   if exists('g:ack_use_dispatch')
     if g:ack_use_dispatch && !exists(':Dispatch')

--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -2,14 +2,6 @@ if exists('g:autoloaded_ack') || &cp
   finish
 endif
 
-if exists('g:ack_use_dispatch')
-  if g:ack_use_dispatch && !exists(':Dispatch')
-    call s:Warn('Dispatch not loaded! Falling back to g:ack_use_dispatch = 0.')
-    let g:ack_use_dispatch = 0
-  endif
-else
-  let g:ack_use_dispatch = 0
-endif
 
 "-----------------------------------------------------------------------------
 " Public API
@@ -162,6 +154,15 @@ endfunction "}}}
 function! s:Init(cmd) "{{{
   let s:searching_filepaths = (a:cmd =~# '-g$') ? 1 : 0
   let s:using_loclist       = (a:cmd =~# '^l') ? 1 : 0
+
+  if exists('g:ack_use_dispatch')
+    if g:ack_use_dispatch && !exists(':Dispatch')
+      call s:Warn('Dispatch not loaded! Falling back to g:ack_use_dispatch = 0.')
+      let g:ack_use_dispatch = 0
+    endif
+  else
+    let g:ack_use_dispatch = 0
+  endif
 
   if g:ack_use_dispatch && s:using_loclist
     call s:Warn('Dispatch does not support location lists! Proceeding with quickfix...')

--- a/doc/ack.txt
+++ b/doc/ack.txt
@@ -220,6 +220,17 @@ Example:
 >
         let g:ack_use_dispatch = 1
 <
+                                                          *g:ack_use_async*
+g:ack_use_async
+Default: 0
+
+Use this option to use async.vim to run searches in the background, leveraging
+async job support added to VIM 8.
+
+Example:
+>
+        let g:ack_use_async = 1
+<
                                              *g:ack_use_cword_for_empty_search*
 g:ack_use_cword_for_empty_search
 Default: 1


### PR DESCRIPTION
Hey,

This PR adds a new `g:ack_use_async` option that once set will configure the plugin to search in the background by using Vim async job API; please note that it uses [async.vim](https://github.com/prabirshrestha/async.vim) internally, so hopefully Neovim support will come for free.

Subscribers of https://github.com/mileszs/ack.vim/issues/209 might be interested in this.