### PR TITLE
Make the 'q' map actually :quit

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -110,9 +110,7 @@ function! s:ApplyMappings() "{{{
     return
   endif
 
-  let l:wintype = s:UsingLocList() ? 'l' : 'c'
-  let l:closemap = ':' . l:wintype . 'close<CR>'
-  let g:ack_mappings.q = l:closemap
+  let g:ack_mappings.q = ':q<CR>'
 
   nnoremap <buffer> <silent> ? :call <SID>QuickHelp()<CR>
 


### PR DESCRIPTION
`:cclose` and `:lclose` will refuse to close the quickfix window if it's the
last window. `:q` doesn't care.

I'll also note that I discovered this because `Ack` was overriding maps I had set up in `~/.vim/after/ftplugin/qf.vim`, which doesn't seem like a good idea. I think we could fix that with a `hasmapto` check or the `<unique>` modifier. Please let me know if I should open an issue for this.