### PR TITLE
Fallback to matching filename with grepformat.

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -21,7 +21,7 @@ function! ack#Ack(cmd, args) "{{{
 
   " Local values that we'll temporarily set as options when searching
   let l:grepprg = g:ackprg
-  let l:grepformat = '%f:%l:%c:%m,%f:%l:%m'  " Include column number
+  let l:grepformat = '%f:%l:%c:%m,%f:%l:%m,%f'  " Include column number
 
   " Strip some options that are meaningless for path search and set match
   " format accordingly.


### PR DESCRIPTION
When one uses the `-l` option to look for just files containing a search term, but not every result:
```
:Ack -l search_term
```
The current results look like:
```
|| csc/models/staging/staging_factory.py
|| csc/models/factory_base.py
|| csc/models/protocols.py
```
Which breaks the quickfix list's ability to jump.

With this changes, the results will now look like:
```
csc/models/staging/staging_factory.py|| 
csc/models/factory_base.py|| 
csc/models/protocols.py|| 
```

Full confession: I'm a ag-based searcher.  And this use case only appears when using a custom `ackprg` value.  Otherwise the default `-H` and the `-l` options are mutually exclusive in ack.