### PR TITLE
"Fix" outputting to terminal every search!

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -207,15 +207,33 @@ endfunction "}}}
 function! s:SearchWithGrep(grepcmd, grepprg, grepargs, grepformat) "{{{
   let l:grepprg_bak    = &l:grepprg
   let l:grepformat_bak = &grepformat
+  if (&shell =~ '\v(bash|zsh)$')
+    let l:saved_shellpipe = &shellpipe
+  else
+    let l:t_te = &t_te
+    let l:t_ti = &t_ti
+  endif
 
   try
     let &l:grepprg  = a:grepprg
     let &grepformat = a:grepformat
+    if (&shell =~ '\v(bash|zsh)$')
+      let &shellpipe = '>'
+    else
+      let t_ti = ''
+      let t_te = ''
+    endif
 
     silent execute a:grepcmd a:grepargs
   finally
     let &l:grepprg  = l:grepprg_bak
     let &grepformat = l:grepformat_bak
+    if (&shell =~ '\v(bash|zsh)$')
+      let &shellpipe = l:saved_shellpipe
+    else
+      let &t_te = l:t_te
+      let &t_ti = l:t_ti
+    endif
   endtry
 endfunction "}}}
 


### PR DESCRIPTION
I wouldn't say it fixes #18 and #52, but it builds on them. It avoids
the compatibility woes, but only using the shell trick if the shell is
bash or zsh. Otherwise it does the t_te/i swapping.

Both are not very neat, and make this function messier, but making 3
separate functions seemed a lot more busy work.
