### PR TITLE
Try to set ackprg on every invocation

### DIFF
--- a/autoload/ack.vim
+++ b/autoload/ack.vim
@@ -16,6 +16,7 @@ endif
 "-----------------------------------------------------------------------------
 
 function! ack#Ack(cmd, args) "{{{
+  call ack#UpdateAckPrg()
   call s:Init(a:cmd)
   redraw
 

--- a/plugin/ack.vim
+++ b/plugin/ack.vim
@@ -6,17 +6,21 @@ if !exists("g:ack_default_options")
   let g:ack_default_options = " -s -H --nopager --nocolor --nogroup --column"
 endif
 
-" Location of the ack utility
-if !exists("g:ackprg")
-  if executable('ack-grep')
-    let g:ackprg = "ack-grep"
-  elseif executable('ack')
-    let g:ackprg = "ack"
-  else
-    finish
+function! ack#UpdateAckPrg() "{{{
+  " Location of the ack utility
+  if !exists("g:ackprg")
+    if executable('ack-grep')
+      let g:ackprg = "ack-grep"
+    elseif executable('ack')
+      let g:ackprg = "ack"
+    else
+      return
+    endif
+    let g:ackprg .= g:ack_default_options
   endif
-  let g:ackprg .= g:ack_default_options
-endif
+endfunction "}}}
+
+call ack#UpdateAckPrg()
 
 if !exists("g:ack_apply_qmappings")
   let g:ack_apply_qmappings = !exists("g:ack_qhandler")


### PR DESCRIPTION
Before this change, plugin would stop initialization unless `g:ackprg` has been found. This would prohibit from loading `:Ack`, `:AckFromSearch` and other autoload commands from being accessible. With this patch, plugin continues initialization when `g:ackprg` is missing and retries setting it when one of the `autoload` commands is called.